### PR TITLE
Replace structopt with clap v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock linguist-generated=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,26 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,17 +43,29 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "b1121e32687f7f90b905d4775273305baa4f32cd418923e9b0fa726533221857"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -117,21 +109,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -192,6 +181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,11 +218,11 @@ checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 name = "linkerd-await"
 version = "0.2.4"
 dependencies = [
+ "clap",
  "http",
  "hyper",
  "nix",
  "regex",
- "structopt",
  "tokio",
 ]
 
@@ -302,6 +301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -392,40 +400,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -434,12 +412,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "tokio"
@@ -502,15 +477,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"
@@ -519,16 +488,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ homepage = "https://linkerd.io"
 repository = "https://github.com/linkerd/linkerd-await"
 
 [dependencies]
+clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 nix = "0.23"
 regex = "1"
-structopt = "0.3"
 tokio = { version = "1", features = ["macros", "process", "rt", "signal", "time"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -4,27 +4,25 @@ A command-wrapper that polls Linkerd for readiness until it becomes ready and on
 
 ## Usage
 
-```
+```text
 linkerd-await 0.2.4
 Wait for linkerd to become ready before running a program
 
 USAGE:
-    linkerd-await [FLAGS] [OPTIONS] [ARGS]
-
-FLAGS:
-    -h, --help        Prints help information
-    -S, --shutdown    Forks the program and triggers proxy shutdown on completion
-    -V, --version     Prints version information
-
-OPTIONS:
-    -b, --backoff <backoff>    Time to wait after a failed readiness check [default: 1s]
-    -p, --port <port>          The port of the local Linkerd proxy admin server [default: 4191]
-    -v, --verbose <verbose>    Causes linkerd-await to print an error message when disabled [env:
-                               LINKERD_AWAIT_VERBOSE=]
+    linkerd-await [OPTIONS] [ARGS]
 
 ARGS:
     <CMD>        The command to run after linkerd is ready
     <ARGS>...    Arguments to pass to CMD if specified
+
+OPTIONS:
+    -b, --backoff <BACKOFF>    Time to wait after a failed readiness check [default: 1s]
+    -h, --help                 Print help information
+    -p, --port <PORT>          The port of the local Linkerd proxy admin server [default: 4191]
+    -S, --shutdown             Forks the program and triggers proxy shutdown on completion
+    -v, --verbose              Causes linkerd-await to print an error message when disabled [env:
+                               LINKERD_AWAIT_VERBOSE=]
+    -V, --version              Print version information
 ```
 
 ## Examples

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,24 @@
 #![deny(warnings, rust_2018_idioms)]
 
+use clap::Parser;
 use regex::Regex;
 use std::{convert::TryInto, error, fmt, io, process::ExitStatus, str::FromStr};
-use structopt::StructOpt;
 use tokio::time;
 
-#[derive(Clone, Debug, StructOpt)]
-#[structopt()]
+#[derive(Clone, Debug, Parser)]
+#[clap(about, version)]
 /// Wait for linkerd to become ready before running a program.
-struct Opt {
-    #[structopt(
-        short = "p",
+struct Args {
+    #[clap(
+        short = 'p',
         long = "port",
         default_value = "4191",
         help = "The port of the local Linkerd proxy admin server"
     )]
     port: u16,
 
-    #[structopt(
-        short = "b",
+    #[clap(
+        short = 'b',
         long = "backoff",
         default_value = "1s",
         parse(try_from_str = parse_duration),
@@ -26,26 +26,26 @@ struct Opt {
     )]
     backoff: time::Duration,
 
-    #[structopt(
-        short = "S",
+    #[clap(
+        short = 'S',
         long = "shutdown",
         help = "Forks the program and triggers proxy shutdown on completion",
         requires("CMD")
     )]
     shutdown: bool,
 
-    #[structopt(
-        short = "v",
+    #[clap(
+        short = 'v',
         long = "verbose",
         help = "Causes linkerd-await to print an error message when disabled",
         env = "LINKERD_AWAIT_VERBOSE"
     )]
     verbose: bool,
 
-    #[structopt(name = "CMD", help = "The command to run after linkerd is ready")]
+    #[clap(name = "CMD", help = "The command to run after linkerd is ready")]
     cmd: Option<String>,
 
-    #[structopt(name = "ARGS", help = "Arguments to pass to CMD if specified")]
+    #[clap(name = "ARGS", help = "Arguments to pass to CMD if specified")]
     args: Vec<String>,
 }
 
@@ -54,14 +54,14 @@ const EX_OSERR: i32 = 71;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let Opt {
+    let Args {
         port,
         backoff,
         shutdown,
         verbose,
         cmd,
         args,
-    } = Opt::from_args();
+    } = Args::parse();
 
     let authority = http::uri::Authority::from_str(&format!("localhost:{}", port))
         .expect("HTTP authority must be valid");


### PR DESCRIPTION
The new version of clap subsumes the `structopt`'s functionality (which
depends on an older version of `clap`). This change eliminates several
unnecessary dependencies.