### PR TITLE
Add readiness timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -88,6 +103,18 @@ name = "futures-core"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+
+[[package]]
+name = "futures-io"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
@@ -102,6 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -215,6 +243,7 @@ name = "linkerd-await"
 version = "0.2.4"
 dependencies = [
  "clap",
+ "futures",
  "http",
  "hyper",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/linkerd/linkerd-await"
 
 [dependencies]
 clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 nix = "0.23"
 regex = "1"
 tokio = { version = "1", features = ["macros", "process", "rt", "signal", "time"] }
-futures = { version = "0.3", default-features = false }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 nix = "0.23"
 regex = "1"
 tokio = { version = "1", features = ["macros", "process", "rt", "signal", "time"] }
+futures = { version = "0.3", default-features = false }
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ use regex::Regex;
 use std::{convert::TryInto, error, fmt, io, process::ExitStatus, str::FromStr};
 use tokio::time;
 
-// #[derive(Clone, Debug)]
-// struct Timeout(time::Duration);
 #[derive(Clone, Debug, Parser)]
 #[clap(about, version)]
 /// Wait for linkerd to become ready before running a program.

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ async fn main() {
         }
         None => {
             let ready = await_ready(authority.clone(), backoff);
-            if let Err(_) = tokio::time::timeout(timeout, ready).await {
+            if tokio::time::timeout(timeout, ready).await.is_err() {
                 eprintln!(
                     "linkerd-proxy failed to become ready within {:?} timeout",
                     timeout

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ struct Args {
         short = 't',
         long = "timeout",
         parse(try_from_str = parse_duration),
-        help = "Causes linked-await to print an error message when the proxy fails to become ready before the timeout has elapsed"
+        help = "Causes linked-await to fail when the timeout elapses before the proxy becomes ready"
     )]
     timeout: time::Duration,
 
@@ -59,6 +59,7 @@ struct Args {
 
 // From https://man.netbsd.org/sysexits.3
 const EX_OSERR: i32 = 71;
+const EX_UNAVAILABLE: i32 = 69;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -90,6 +91,7 @@ async fn main() {
                     "linkerd-proxy failed to become ready within {:?} timeout",
                     timeout
                 );
+                std::process::exit(EX_UNAVAILABLE)
             }
 
             if shutdown {


### PR DESCRIPTION
This change adds a timeout flag which will cause `linkers-await` to exit if the proxy fails to become ready within the given timeout. This will be used by linkerd/linkerd2#7659 and there is a [comment](https://github.com/linkerd/linkerd2/issues/7659#issuecomment-1024691969) explaining how it appears when the proxy fails to become ready.

Local testing is shown below

```
$ make build
$ ./target/x86_64-unknown-linux-gnu/debug/linkerd-await -t 1s
linkerd-proxy failed to become ready within 1s timeout
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>