### PR TITLE
Prepare for v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "linkerd-await"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd-await"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2021"
 publish = false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-wrapper that polls Linkerd for readiness until it becomes ready and on
 ## Usage
 
 ```text
-linkerd-await 0.2.4
+linkerd-await 0.2.5
 Wait for linkerd to become ready before running a program
 
 USAGE:
@@ -20,6 +20,8 @@ OPTIONS:
     -h, --help                 Print help information
     -p, --port <PORT>          The port of the local Linkerd proxy admin server [default: 4191]
     -S, --shutdown             Forks the program and triggers proxy shutdown on completion
+    -t, --timeout <TIMEOUT>    Causes linked-await to fail when the timeout elapses before the proxy
+                               becomes ready
     -v, --verbose              Causes linkerd-await to print an error message when disabled [env:
                                LINKERD_AWAIT_VERBOSE=]
     -V, --version              Print version information
@@ -32,7 +34,7 @@ OPTIONS:
 ```dockerfile
 # Create a base layer with linkerd-await from a recent release.
 FROM docker.io/curlimages/curl:latest as linkerd
-ARG LINKERD_AWAIT_VERSION=v0.2.4
+ARG LINKERD_AWAIT_VERSION=v0.2.5
 RUN curl -sSLo /tmp/linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-amd64 && \
     chmod 755 /tmp/linkerd-await
 


### PR DESCRIPTION
This release updates `linkerd-await` to support an optional `--timeout`
flag that causes `linkerd-await` to fail if the proxy doesn't become
ready within the specified timeout.