### PR TITLE
build(deps): update `regex` to 1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
Fixes linkerd/linkerd2#8029

`regex` v1.5.5 fixes a denial-of-service vulnerability when parsing
untrusted regular expressions ([RUSTSEC-2022-0013]). This bump should
fix the `cargo audit` failure for that vulnerability.

I don't know why dependabot didn't open a PR for this one?

[RUSTSEC-2022-0013]: https://rustsec.org/advisories/RUSTSEC-2022-0013.html