### PR TITLE
Remove `regex` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +232,6 @@ dependencies = [
  "http",
  "hyper",
  "nix",
- "regex",
  "tokio",
 ]
 
@@ -382,23 +372,6 @@ checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 nix = "0.23"
-regex = "1"
 tokio = { version = "1", features = ["macros", "process", "rt", "signal", "time"] }
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use clap::Parser;
-use regex::Regex;
 use std::{convert::TryInto, error, fmt, io, process::ExitStatus, str::FromStr};
 use tokio::time;
 
@@ -239,18 +238,25 @@ async fn send_shutdown(auth: http::uri::Authority) {
 
 fn parse_duration(s: &str) -> Result<time::Duration, InvalidDuration> {
     use tokio::time::Duration;
-    let re = Regex::new(r"^\s*(\d+)(ms|s|m|h|d)?\s*$").expect("duration regex");
-    let cap = re.captures(s).ok_or(InvalidDuration)?;
-    let magnitude = cap[1].parse().map_err(|_| InvalidDuration)?;
-    match cap.get(2).map(|m| m.as_str()) {
-        None if magnitude == 0 => Ok(Duration::from_secs(0)),
-        Some("ms") => Ok(Duration::from_millis(magnitude)),
-        Some("s") => Ok(Duration::from_secs(magnitude)),
-        Some("m") => Ok(Duration::from_secs(magnitude * 60)),
-        Some("h") => Ok(Duration::from_secs(magnitude * 60 * 60)),
-        Some("d") => Ok(Duration::from_secs(magnitude * 60 * 60 * 24)),
-        _ => Err(InvalidDuration),
-    }
+    let s = s.trim();
+    let milliseconds = match s.rfind(|c: char| c.is_digit(10)) {
+        None => return Err(InvalidDuration),
+        Some(index) => {
+            let (magnitude, unit) = s.split_at(index + 1);
+            let magnitude = u64::from_str(magnitude).map_err(|_| InvalidDuration)?;
+            let multiplier = match unit {
+                "" if magnitude == 0 => 0,
+                "ms" => 1,
+                "s" => 1000,
+                "m" => 1000 * 60,
+                "h" => 1000 * 60 * 60,
+                "d" => 1000 * 60 * 60 * 24,
+                _ => return Err(InvalidDuration),
+            };
+            magnitude.checked_mul(multiplier).ok_or(InvalidDuration)?
+        }
+    };
+    Ok(Duration::from_millis(milliseconds))
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -278,6 +284,10 @@ mod tests {
         assert_eq!(parse_duration("0x"), Err(InvalidDuration));
         assert_eq!(parse_duration("123x"), Err(InvalidDuration));
         assert_eq!(parse_duration("  123x  "), Err(InvalidDuration));
+        assert_eq!(
+            parse_duration(&format!("{}s", u64::MAX)),
+            Err(InvalidDuration),
+        );
     }
 
     #[test]
@@ -294,6 +304,10 @@ mod tests {
         assert_eq!(
             parse_duration("10d"),
             Ok(Duration::from_secs(10 * 60 * 60 * 24))
+        );
+        assert_eq!(
+            parse_duration(&format!("{}ms", u64::MAX)),
+            Ok(Duration::from_millis(u64::MAX)),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ fn parse_duration(s: &str) -> Result<time::Duration, InvalidDuration> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct InvalidDuration;
 
 impl fmt::Display for InvalidDuration {
@@ -263,3 +263,37 @@ impl fmt::Display for InvalidDuration {
 }
 
 impl error::Error for InvalidDuration {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert_eq!(parse_duration(""), Err(InvalidDuration));
+        assert_eq!(parse_duration("  "), Err(InvalidDuration));
+        assert_eq!(parse_duration("\t\n"), Err(InvalidDuration));
+        assert_eq!(parse_duration("x"), Err(InvalidDuration));
+        assert_eq!(parse_duration("1"), Err(InvalidDuration));
+        assert_eq!(parse_duration("0x"), Err(InvalidDuration));
+        assert_eq!(parse_duration("123x"), Err(InvalidDuration));
+        assert_eq!(parse_duration("  123x  "), Err(InvalidDuration));
+    }
+
+    #[test]
+    fn test_parse_duration_valid() {
+        use tokio::time::Duration;
+        assert_eq!(parse_duration("0"), Ok(Duration::from_secs(0)));
+        assert_eq!(parse_duration("0s"), Ok(Duration::from_secs(0)));
+        assert_eq!(parse_duration("1ms"), Ok(Duration::from_millis(1)));
+        assert_eq!(parse_duration("1s"), Ok(Duration::from_secs(1)));
+        assert_eq!(parse_duration(" \n12s  \t"), Ok(Duration::from_secs(12)));
+        assert_eq!(parse_duration("10s"), Ok(Duration::from_secs(10)));
+        assert_eq!(parse_duration("10m"), Ok(Duration::from_secs(10 * 60)));
+        assert_eq!(parse_duration("10h"), Ok(Duration::from_secs(10 * 60 * 60)));
+        assert_eq!(
+            parse_duration("10d"),
+            Ok(Duration::from_secs(10 * 60 * 60 * 24))
+        );
+    }
+}


### PR DESCRIPTION
Adds tests for `parse_duration` and then replaces the regex-based parse with a simple `find` & `split_at` implementation. This cuts ~5s off a clean compile time (22s -> 15s) and 1MB (2.6MB -> 1.6MB) from the final stripped binary. This is, IMO, without any loss in readability, but of course this is subjective.