### PR TITLE
Shutdown the proxy if the child process can't be forked

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,7 @@ async fn fork_with_sigterm(cmd: String, args: Vec<String>) -> io::Result<ExitSta
         sys::signal::{kill, Signal::SIGTERM},
         unistd::Pid,
     };
+    use std::os::unix::process::ExitStatusExt;
     use tokio::{
         process::Command,
         signal::unix::{signal, SignalKind},
@@ -175,7 +176,7 @@ async fn fork_with_sigterm(cmd: String, args: Vec<String>) -> io::Result<ExitSta
         Ok(child) => child,
         Err(e) => {
             eprintln!("Failed to fork child program: {}: {}", cmd, e);
-            std::process::exit(EX_OSERR);
+            return Ok(ExitStatus::from_raw(EX_OSERR));
         }
     };
 


### PR DESCRIPTION
Hello, Linkerd team!

My company uses linkerd-await in all our application containers 😄  

The other day I noticed some stale Kubernetes pods. I had made a typo in the entrypoint script, specifying a nonexistent executable. But the linkerd-proxy containers were still running.

In my understanding, if we have an entrypoint like this:
```
/linkerd-await --shutdown -- some-nonexistent-command
```

then linkerd-await will fail to fork `some-nonexistent-command` and exit immediately:
https://github.com/linkerd/linkerd-await/blob/8a35095a53df7a078f279d4d376b298ee7fd67d0/src/main.rs#L178
and so this shutdown logic is never executed:
https://github.com/linkerd/linkerd-await/blob/8a35095a53df7a078f279d4d376b298ee7fd67d0/src/main.rs#L113-L115
and so the proxy container continues to run.

This change uses the ExitStatusExt trait to "fake" a child exit code, allowing the shutdown logic to run. (ExitStatusExt is unix-only, but linkerd-await already uses the `nix` crate, which appears to be unix-only too.)

Thank you for your time and consideration!