### PR TITLE
Introduce --timeout-fatal to control readiness timeouts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,12 +34,11 @@ struct Args {
     shutdown: bool,
 
     #[clap(
-        short = 'F',
-        long = "force-exec",
-        help = "Runs CMD even if the proxy is not yet ready prior to timeout",
+        long = "timeout-non-fatal",
+        help = "Allows the command or shutdown to execute independently of the status of the proxy. (Normally linkerd-await will exit immediately if the proxy is not yet ready prior to timeout.)",
         requires("CMD")
     )]
-    force: bool,
+    timeoutnonfatal: bool,
 
     #[clap(
         short = 'v',
@@ -74,7 +73,7 @@ async fn main() {
         port,
         backoff,
         shutdown,
-        force,
+        timeoutnonfatal,
         verbose,
         timeout,
         cmd,
@@ -110,8 +109,9 @@ async fn main() {
                         timeout
                     );
 
-                    // If force-execute is configured, don't exit, but rather continue to execute command and try proxy shutdown
-                    if !force {
+                    // If timeoutfatal is true, exit. Otherwise, continue to execute command and try proxy shutdown
+                    let timeoutfatal = !timeoutnonfatal;
+                    if timeoutfatal {
                         std::process::exit(EX_UNAVAILABLE)
                     }
                     

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,14 @@ struct Args {
     shutdown: bool,
 
     #[clap(
+        short = 'F',
+        long = "force-exec",
+        help = "Runs CMD even if the proxy is not yet ready prior to timeout",
+        requires("CMD")
+    )]
+    force: bool,
+
+    #[clap(
         short = 'v',
         long = "verbose",
         help = "Causes linkerd-await to print an error message when disabled",
@@ -66,6 +74,7 @@ async fn main() {
         port,
         backoff,
         shutdown,
+        force,
         verbose,
         timeout,
         cmd,
@@ -100,7 +109,12 @@ async fn main() {
                         "linkerd-proxy failed to become ready within {:?} timeout",
                         timeout
                     );
-                    std::process::exit(EX_UNAVAILABLE)
+
+                    // If force-execute is configured, don't exit, but rather continue to execute command and try proxy shutdown
+                    if !force {
+                        std::process::exit(EX_UNAVAILABLE)
+                    }
+                    
                 }
             }
             if shutdown {


### PR DESCRIPTION
Problem Statement: I want to ensure that when linkerd-await is used for `shutdown` purposes, it will run its given command both in the case that the proxy sidecar container is injected to the pod, but also in the case where that proxy is not injected. The motivation here is that I have some cronjobs which need to run the same configured job in both a meshed, and possibly also unmeshed configuration, but where it's not practical to set the `DISABLE` environment variable in advance.

Under these conditions, the current behavior of linkerd-await leads to a timeout in the absence of the proxy and the job fails.

This modification allows linkerd-await to execute a command of a k8s job in either case where the proxy is or is not present.

I'm glad to take feedback and questions on this proposal.