### PR TITLE
feat!(ci): Remove arm/v7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,11 @@ jobs:
     needs: [meta]
     strategy:
       matrix:
-        arch: [amd64, arm64, arm]
+        arch: [amd64, arm64]
         os: [windows, linux]
         exclude:
           - os: windows
             arch: arm64
-          - os: windows
-            arch: arm
     name: Package (${{ matrix.arch }}-${{ matrix.os }})
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
-    { triple = "armv7-unknown-linux-gnu" },
 ]
 
 [advisories]

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ _cargo := env_var_or_default("CARGO", "cargo" + if toolchain != "" { " +" + tool
 # The version name to use for packages.
 package_version := env_var_or_default("PACKAGE_VERSION", `git rev-parse --short HEAD`)
 
-# The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
+# The architecture name to use for packages. Either 'amd64' or 'arm64'.
 package_arch := env_var_or_default("ARCH", "amd64")
 
 os := env_var_or_default("OS", "linux")
@@ -26,8 +26,6 @@ _cargo_target := if os + '-' + package_arch == "linux-amd64" {
         "x86_64-unknown-linux-musl"
     } else if os + '-' + package_arch == "linux-arm64" {
         "aarch64-unknown-linux-musl"
-    } else if os + '-' + package_arch == "linux-arm" {
-        "armv7-unknown-linux-musleabihf"
     } else if os + '-' + package_arch == "windows-amd64" {
         "x86_64-pc-windows-gnu"
     } else {
@@ -36,8 +34,7 @@ _cargo_target := if os + '-' + package_arch == "linux-amd64" {
 
 # Support cross-compilation when `package_arch` changes.
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER := "aarch64-linux-gnu-gcc"
-export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER := "arm-linux-gnueabihf-gcc"
-_strip := if package_arch == "arm64" { "aarch64-linux-gnu-strip" } else if package_arch == "arm" { "arm-linux-gnueabihf-strip" } else { "strip" }
+_strip := if package_arch == "arm64" { "aarch64-linux-gnu-strip" } else { "strip" }
 
 _target_dir := "target" / _cargo_target / build_type
 _target_bin := _target_dir / "linkerd-await" + if os == 'windows' { '.exe' } else { '' }


### PR DESCRIPTION
This architecture has become too significant of a maintenance burden, and isn't used often enough to justify the associated maintenance cost.

This removes arm/v7 from all the build infrastructure/dockerfiles/etc. Note that arm64 targets are still widely used and well supported.

Related: https://github.com/linkerd/linkerd2/pull/14308