### PR TITLE
fix: restore --help/-h flags (clap help/usage features were missing)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 [dependencies.clap]
 version = "4"
 default-features = false
-features = ["derive", "env", "std"]
+features = ["derive", "env", "help", "std", "usage"]
 
 [dependencies.nix]
 version = "0.31"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ only then executes a command.
 ## Usage
 
 ```text
-linkerd-await 0.2.9
+linkerd-await 0.3.1
 Wait for linkerd to become ready before running a program
 
 Usage: linkerd-await [OPTIONS] [CMD] [ARGS]...
@@ -25,7 +25,7 @@ Options:
   -v, --verbose
           Causes linkerd-await to print an error message when disabled [env: LINKERD_AWAIT_VERBOSE=]
   -t, --timeout <TIMEOUT>
-          Causes linked-await to fail when the timeout elapses before the proxy becomes ready
+          Causes linkerd-await to fail when the timeout elapses before the proxy becomes ready
       --timeout-fatal[=<TIMEOUT_FATAL>]
           Controls whether a readiness timeout failure prevents CMD from running [default: true] [possible values: true, false]
   -h, --help

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct Args {
         short = 't',
         long = "timeout",
         value_parser = parse_duration,
-        help = "Causes linked-await to fail when the timeout elapses before the proxy becomes ready"
+        help = "Causes linkerd-await to fail when the timeout elapses before the proxy becomes ready"
     )]
     timeout: Option<time::Duration>,
 
@@ -250,7 +250,7 @@ async fn fork_with_shutdown(cmd: String, args: Vec<String>) -> io::Result<ExitSt
         use tokio::signal::windows::{ctrl_break, ctrl_c};
 
         let mut ctrl_break = ctrl_break().expect("Failed to register Ctrl-Break handler");
-        let mut ctrl_c = ctrl_c().expect("Failed to register  Ctrl-C handler");
+        let mut ctrl_c = ctrl_c().expect("Failed to register Ctrl-C handler");
 
         // Wait for either the child to exit, or a console signal
         let exit = tokio::select! {


### PR DESCRIPTION
`--help` and `-h` are broken rn - they return `error: unexpected argument found` instead of printing help.

Root cause: `Cargo.toml` sets `default-features = false` for clap but doesn't include the `help` and `usage` features (they're part of clap's defaults but get dropped when you opt out).

Fix: add `"help"` and `"usage"` to clap's feature list. Also fix a typo in the `--timeout` help string (`linked-await` -> `linkerd-await`) and update the README usage block to match current output.

How to repro (before fix):

```
cargo build
./target/debug/linkerd-await --help
# error: unexpected argument found
```

Signed-off-by: Immanuel Tikhonov <pchpr.00@list.ru>