### PR TITLE
fix: preserve shutdown mode when readiness checks are disabled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,29 +124,29 @@ async fn main() {
 
                 }
             }
-            if shutdown {
-                let cmd = cmd.expect("Command must be specified with --shutdown");
+        }
+    }
 
-                // If shutdown is configured, fork the process and proxy
-                // shutdown signals to it.
-                let ex = fork_with_shutdown(cmd, args).await;
+    if shutdown {
+        let cmd = cmd.expect("Command must be specified with --shutdown");
 
-                // Once the process completes, issue a shutdown request to the
-                // proxy.
-                send_shutdown(authority).await;
+        // If shutdown is configured, fork the process and proxy shutdown
+        // signals to it.
+        let ex = fork_with_shutdown(cmd, args).await;
 
-                // Try to exit with the process's original exit code
-                if let Ok(status) = ex {
-                    if let Some(code) = status.code() {
-                        std::process::exit(code);
-                    }
-                }
+        // Once the process completes, issue a shutdown request to the proxy.
+        send_shutdown(authority).await;
 
-                // If we didn't get an exit code from the forked program, fail
-                // with an OS error.
-                std::process::exit(EX_OSERR);
+        // Try to exit with the process's original exit code
+        if let Ok(status) = ex {
+            if let Some(code) = status.code() {
+                std::process::exit(code);
             }
         }
+
+        // If we didn't get an exit code from the forked program, fail with an
+        // OS error.
+        std::process::exit(EX_OSERR);
     }
 
     if let Some(cmd) = cmd {

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -1,0 +1,102 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    process::Command,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+#[test]
+fn disabled_mode_still_triggers_shutdown() {
+    let (port, shutdown_hits, stop) = start_admin_server();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_linkerd-await"))
+        .env("LINKERD_AWAIT_DISABLED", "1")
+        .args(["--port", &port.to_string(), "--shutdown", "--", "/bin/true"])
+        .status()
+        .expect("binary should run");
+
+    assert!(status.success());
+    assert_shutdown_hits(&shutdown_hits, 1);
+
+    stop.store(true, Ordering::Relaxed);
+}
+
+#[test]
+fn shutdown_mode_triggers_shutdown_after_readiness() {
+    let (port, shutdown_hits, stop) = start_admin_server();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_linkerd-await"))
+        .args(["--port", &port.to_string(), "--shutdown", "--", "/bin/true"])
+        .status()
+        .expect("binary should run");
+
+    assert!(status.success());
+    assert_shutdown_hits(&shutdown_hits, 1);
+
+    stop.store(true, Ordering::Relaxed);
+}
+
+fn start_admin_server() -> (u16, Arc<AtomicUsize>, Arc<AtomicBool>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listener should bind");
+    listener
+        .set_nonblocking(true)
+        .expect("listener should become nonblocking");
+    let port = listener
+        .local_addr()
+        .expect("listener should have a local address")
+        .port();
+
+    let shutdown_hits = Arc::new(AtomicUsize::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let thread_shutdown_hits = Arc::clone(&shutdown_hits);
+    let thread_stop = Arc::clone(&stop);
+    thread::spawn(move || {
+        while !thread_stop.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0; 1024];
+                    let n = stream.read(&mut buf).expect("request should be readable");
+                    let req = std::str::from_utf8(&buf[..n]).expect("request must be utf-8");
+
+                    let response = if req.starts_with("GET /ready ") {
+                        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nready"
+                    } else if req.starts_with("POST /shutdown ") {
+                        thread_shutdown_hits.fetch_add(1, Ordering::Relaxed);
+                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+                    } else {
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+                    };
+
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("response should be writable");
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => panic!("listener accept failed: {e}"),
+            }
+        }
+    });
+
+    (port, shutdown_hits, stop)
+}
+
+fn assert_shutdown_hits(shutdown_hits: &AtomicUsize, expected: usize) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+
+    while Instant::now() < deadline {
+        if shutdown_hits.load(Ordering::Relaxed) == expected {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    assert_eq!(shutdown_hits.load(Ordering::Relaxed), expected);
+}


### PR DESCRIPTION
Small follow-up to #20.

`LINKERD_AWAIT_DISABLED` is meant to skip readiness checks, but it also skipped `--shutdown`. Kinda sneaky. For jobs and cronjobs that means the child can exit, but the proxy never gets `/shutdown`.

This patch keeps the disable env scoped to readiness checks only, and adds a regression test for it.

Repro:
1. Start a local admin server on port `4191` and count `POST /shutdown`.
2. Run `LINKERD_AWAIT_DISABLED=1 linkerd-await --shutdown -- /bin/true`.
3. Before this patch, the counter stays at `0`.
4. With this patch, it becomes `1`.
